### PR TITLE
[martools] command conflict

### DIFF
--- a/martools/__init__.py
+++ b/martools/__init__.py
@@ -17,7 +17,7 @@ async def setup_after_ready(bot: Red):
                 command.name = f"m{command.name}"
             for alias in command.aliases:
                 if bot.get_command(alias):
-                    command.aliases[command.aliases.index(alias)] = f"i{alias}"
+                    command.aliases[command.aliases.index(alias)] = f"m{alias}"
     bot.add_cog(cog)
 
 

--- a/martools/__init__.py
+++ b/martools/__init__.py
@@ -1,3 +1,4 @@
+from asyncio import create_task
 from redbot.core.bot import Red
 from .marttools import MartTools
 
@@ -6,6 +7,19 @@ __red_end_user_data_statement__ = (
 )
 
 
-def setup(bot: Red):
+# from https://github.com/fixator10/Fixator10-Cogs/blob/V3/adminutils/__init__.py
+async def setup_after_ready(bot: Red):
+    await bot.wait_until_red_ready()
     cog = MartTools(bot)
+    for name, command in cog.all_commands.items():
+        if not command.parent:
+            if bot.get_command(name):
+                command.name = f"m{command.name}"
+            for alias in command.aliases:
+                if bot.get_command(alias):
+                    command.aliases[command.aliases.index(alias)] = f"i{alias}"
     bot.add_cog(cog)
+
+
+def setup(bot: Red):
+    create_task(setup_after_ready(bot))


### PR DESCRIPTION
Renames martools commands to be prefixed with `m` if they are conflicting, such as `mprefix`.