### PR TITLE
[MartTools] Fix performance issues.

### DIFF
--- a/martools/__init__.py
+++ b/martools/__init__.py
@@ -6,6 +6,7 @@ __red_end_user_data_statement__ = (
 )
 
 
-def setup(bot: Red):
+async def setup(bot: Red):
     cog = MartTools(bot)
     bot.add_cog(cog)
+    await cog.initialize()

--- a/martools/__init__.py
+++ b/martools/__init__.py
@@ -6,7 +6,6 @@ __red_end_user_data_statement__ = (
 )
 
 
-async def setup(bot: Red):
+def setup(bot: Red):
     cog = MartTools(bot)
     bot.add_cog(cog)
-    await cog.initialize()

--- a/martools/info.json
+++ b/martools/info.json
@@ -6,6 +6,6 @@
   "description": "Multiple tools that are originally used on Martine (https://martinebot.com).",
   "tags": ["tools", "utility", "information", "counters", "statistics"],
   "requirements": ["apsw-wheels", "babel"],
-  "min_bot_version": "3.3.10",
+  "min_bot_version": "3.4.0",
   "end_user_data_statement": "This cog does not persistently store data or metadata about users."
 }

--- a/martools/listeners.py
+++ b/martools/listeners.py
@@ -1,48 +1,16 @@
 import discord
-from redbot.core.bot import Red
+from redbot.cogs.audio.audio_dataclasses import Query
 from redbot.core import commands
-from redbot.core.data_manager import cog_data_path
-
-import apsw
-import time
-
-from .utils import rgetattr, threadexec
-from .statements import (
-    PRAGMA_journal_mode,
-    PRAGMA_wal_autocheckpoint,
-    # PRAGMA_read_uncommitted,
-    CREATE_TABLE_PERMA,
-    DROP_TEMP,
-    CREATE_TABLE_TEMP,
-    INSERT_PERMA_DO_NOTHING,
-    UPSERT_PERMA,
-    UPSERT_TEMP,
-)
-
-try:
-    from redbot.cogs.audio.audio_dataclasses import Query
-except ImportError:
-    Query = None
+from redbot.core.bot import Red
 
 
 class Listeners:
-    def __init__(self):
-        self.bot: Red
+    bot: Red
+    cache: dict
 
-        self._connection = apsw.Connection(str(cog_data_path(self) / "MartTools.db"))
-        self.cursor = self._connection.cursor()
-
-        threadexec(self.cursor.execute, PRAGMA_journal_mode)
-        threadexec(self.cursor.execute, PRAGMA_wal_autocheckpoint)
-        threadexec(self.cursor.execute, CREATE_TABLE_PERMA)
-        threadexec(self.cursor.execute, DROP_TEMP)
-        threadexec(self.cursor.execute, CREATE_TABLE_TEMP)
-        threadexec(self.cursor.execute, INSERT_PERMA_DO_NOTHING, (-1000, "creation_time", time.time()))
-
-    def upsert(self, id: int, event: str):
-        threadexec(self.cursor.execute, UPSERT_PERMA, (id, event))
-        threadexec(self.cursor.execute, UPSERT_TEMP, (id, event))
-
+    def upsert(self, key: str, value: int = 1):
+        self.cache["perma"][key] += value
+        self.cache["session"][key] += value
 
     @commands.Cog.listener()
     async def on_command_error(self, ctx, error, unhandled_by_cog=False):
@@ -54,94 +22,84 @@ class Listeners:
                 if commands.Cog._get_overridden_method(ctx.cog.cog_command_error) is not None:
                     return
         if isinstance(error, commands.CommandInvokeError):
-            self.upsert(
-                rgetattr(ctx, "guild.id", rgetattr(ctx, "channel.id", -1)), "command_error"
-            )
+            self.upsert("command_error")
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
         if message.author.id == self.bot.user.id:
-            self.upsert(rgetattr(message, "guild.id", -1), "msg_sent")
+            self.upsert("msg_sent")
         if message.guild is None:
-            self.upsert(rgetattr(message, "channel.id", -1), "dms_received")
-        self.upsert(
-            rgetattr(message, "guild.id", rgetattr(message, "channel.id", -1)), "messages_read"
-        )
+            self.upsert("dms_received")
+        self.upsert("messages_read")
 
     @commands.Cog.listener()
     async def on_guild_join(self, guild: discord.Guild):
-        self.upsert(rgetattr(guild, "id", -1), "guild_join")
+        self.upsert("guild_join")
 
     @commands.Cog.listener()
     async def on_guild_remove(self, guild: discord.Guild):
-        self.upsert(rgetattr(guild, "id", -1), "guild_remove")
+        self.upsert("guild_remove")
 
     @commands.Cog.listener()
     async def on_resumed(self):
-        self.upsert(0, "sessions_resumed")
+        self.upsert("sessions_resumed")
 
     @commands.Cog.listener()
     async def on_command(self, ctx: commands.Context):
-        self.upsert(
-            rgetattr(ctx, "guild.id", rgetattr(ctx, "channel.id", -1)), "processed_commands"
-        )
+        self.upsert("processed_commands")
 
     @commands.Cog.listener()
     async def on_member_join(self, member):
-        self.upsert(rgetattr(member, "guild.id", -1), "new_members")
+        self.upsert("new_members")
 
     @commands.Cog.listener()
     async def on_member_remove(self, member):
-        self.upsert(rgetattr(member, "guild.id", -1), "members_left")
+        self.upsert("members_left")
 
     @commands.Cog.listener()
     async def on_message_delete(self, message):
-        self.upsert(
-            rgetattr(message, "guild.id", rgetattr(message, "channel.id", -1)), "messages_deleted"
-        )
+        self.upsert("messages_deleted")
 
     @commands.Cog.listener()
     async def on_message_edit(self, before, after):
-        self.upsert(
-            rgetattr(after, "guild.id", rgetattr(after, "channel.id", -1)), "messages_edited"
-        )
+        self.upsert("messages_edited")
 
     @commands.Cog.listener()
     async def on_reaction_add(self, reaction, user):
-        self.upsert(rgetattr(user, "guild.id", user.id), "reactions_added")
+        self.upsert("reactions_added")
 
     @commands.Cog.listener()
     async def on_reaction_remove(self, reaction, user):
-        self.upsert(rgetattr(user, "guild.id", user.id), "reactions_removed")
+        self.upsert("reactions_removed")
 
     @commands.Cog.listener()
     async def on_guild_role_create(self, role):
-        self.upsert(rgetattr(role.guild, "id", -1), "roles_added")
+        self.upsert("roles_added")
 
     @commands.Cog.listener()
     async def on_guild_role_delete(self, role):
-        self.upsert(rgetattr(role.guild, "id", -1), "roles_removed")
+        self.upsert("roles_removed")
 
     @commands.Cog.listener()
     async def on_guild_role_update(self, before, after):
-        self.upsert(rgetattr(after.guild, "id", -1), "roles_updated")
+        self.upsert("roles_updated")
 
     @commands.Cog.listener()
     async def on_member_ban(self, guild, user):
-        self.upsert(rgetattr(guild, "id", -1), "members_banned")
+        self.upsert("members_banned")
 
     @commands.Cog.listener()
     async def on_member_unban(self, guild, user):
-        self.upsert(rgetattr(guild, "id", -1), "members_unbanned")
+        self.upsert("members_unbanned")
 
     @commands.Cog.listener()
     async def on_guild_emojis_update(self, guild, before, after):
         if len(before) > len(after):
-            self.upsert(rgetattr(guild, "id", -1), "emojis_removed")
+            self.upsert("emojis_removed")
         elif len(before) < len(after):
-            self.upsert(rgetattr(guild, "id", -1), "emojis_added")
+            self.upsert("emojis_added")
         else:
-            self.upsert(rgetattr(guild, "id", -1), "emojis_updated")
+            self.upsert("emojis_updated")
 
     @commands.Cog.listener()
     async def on_voice_state_update(
@@ -152,41 +110,38 @@ class Listeners:
         guild = after.channel.guild
         bot_in_room = guild.me in after.channel.members
         if bot_in_room:
-            self.upsert(rgetattr(member, "guild.id", -1), "users_joined_bot_music_room")
+            self.upsert("users_joined_bot_music_room")
 
     @commands.Cog.listener()
     async def on_red_audio_track_start(self, guild, track, requester):
         if not Query:
             return
-        self.upsert(rgetattr(guild, "id", -1), "tracks_played")
+        self.upsert("tracks_played")
         cog = self.bot.get_cog("Audio")
-        if hasattr(cog, "local_folder_current_path"):
-            query = Query.process_input(
-                query=track.uri, _local_folder_current_path=cog.local_folder_current_path
-            )
-        else:
-            query = Query.process_input(query=track.uri)
+        query = Query.process_input(
+            query=track.uri, _local_folder_current_path=cog.local_folder_current_path
+        )
         if track.is_stream:
-            self.upsert(rgetattr(guild, "id", -1), "streams_played")
+            self.upsert("streams_played")
         if track.is_stream and query.is_youtube:
-            self.upsert(rgetattr(guild, "id", -1), "yt_streams_played")
+            self.upsert("yt_streams_played")
         if track.is_stream and query.is_mixer:
-            self.upsert(rgetattr(guild, "id", -1), "mixer_streams_played")
+            self.upsert("mixer_streams_played")
         if track.is_stream and query.is_twitch:
-            self.upsert(rgetattr(guild, "id", -1), "ttv_streams_played")
+            self.upsert("ttv_streams_played")
         if track.is_stream and query.is_other:
-            self.upsert(rgetattr(guild, "id", -1), "other_streams_played")
+            self.upsert("other_streams_played")
         if query.is_youtube:
-            self.upsert(rgetattr(guild, "id", -1), "youtube_tracks")
+            self.upsert("youtube_tracks")
         if query.is_soundcloud:
-            self.upsert(rgetattr(guild, "id", -1), "soundcloud_tracks")
+            self.upsert("soundcloud_tracks")
         if query.is_bandcamp:
-            self.upsert(rgetattr(guild, "id", -1), "bandcamp_tracks")
+            self.upsert("bandcamp_tracks")
         if query.is_vimeo:
-            self.upsert(rgetattr(guild, "id", -1), "vimeo_tracks")
+            self.upsert("vimeo_tracks")
         if query.is_mixer:
-            self.upsert(rgetattr(guild, "id", -1), "mixer_tracks")
+            self.upsert("mixer_tracks")
         if query.is_twitch:
-            self.upsert(rgetattr(guild, "id", -1), "twitch_tracks")
+            self.upsert("twitch_tracks")
         if query.is_other:
-            self.upsert(rgetattr(guild, "id", -1), "other_tracks")
+            self.upsert("other_tracks")

--- a/martools/listeners.py
+++ b/martools/listeners.py
@@ -1,3 +1,5 @@
+import contextlib
+
 import discord
 from redbot.cogs.audio.audio_dataclasses import Query
 from redbot.core import commands
@@ -9,8 +11,9 @@ class Listeners:
     cache: dict
 
     def upsert(self, key: str, value: int = 1):
-        self.cache["perma"][key] += value
-        self.cache["session"][key] += value
+        with contextlib.suppress(AttributeError):
+            self.cache["perma"][key] += value
+            self.cache["session"][key] += value
 
     @commands.Cog.listener()
     async def on_command_error(self, ctx, error, unhandled_by_cog=False):

--- a/martools/listeners.py
+++ b/martools/listeners.py
@@ -125,8 +125,6 @@ class Listeners:
             self.upsert("streams_played")
         if track.is_stream and query.is_youtube:
             self.upsert("yt_streams_played")
-        if track.is_stream and query.is_mixer:
-            self.upsert("mixer_streams_played")
         if track.is_stream and query.is_twitch:
             self.upsert("ttv_streams_played")
         if track.is_stream and query.is_other:
@@ -139,8 +137,6 @@ class Listeners:
             self.upsert("bandcamp_tracks")
         if query.is_vimeo:
             self.upsert("vimeo_tracks")
-        if query.is_mixer:
-            self.upsert("mixer_tracks")
         if query.is_twitch:
             self.upsert("twitch_tracks")
         if query.is_other:

--- a/martools/marttools.py
+++ b/martools/marttools.py
@@ -95,6 +95,9 @@ class MartTools(Listeners, commands.Cog):
             old_value = result[0][0]
             threadexec(self.cursor.execute, UPSERT, (event_name, old_value))
 
+        old_value = list(threadexec(self.cursor.execute, SELECT_OLD, {"event": "creation_time"}))
+        threadexec(self.cursor.execute, UPSERT, ("creation_time", old_value if old_value else time.time()))
+
         threadexec(self.cursor.execute, DROP_OLD_TEMP)
         threadexec(self.cursor.execute, DROP_OLD_PERMA)
         threadexec(
@@ -116,7 +119,7 @@ class MartTools(Listeners, commands.Cog):
             self.cache["perma"][event_name] = result[0][0]
 
         result = list(threadexec(self.cursor.execute, GET_EVENT_VALUE, {"event": "creation_time"}))
-        self.cache["perma"]["creation_time"] = result[0][0] if result else 0
+        self.cache["perma"]["creation_time"] = result[0][0] if result else time.time()
 
     async def __dump_cache_to_db(self):
         await self.bot.wait_until_red_ready()

--- a/martools/marttools.py
+++ b/martools/marttools.py
@@ -96,7 +96,7 @@ class MartTools(Listeners, commands.Cog):
             threadexec(self.cursor.execute, UPSERT, (event_name, old_value))
 
         old_value = list(threadexec(self.cursor.execute, SELECT_OLD, {"event": "creation_time"}))
-        threadexec(self.cursor.execute, UPSERT, ("creation_time", old_value if old_value else time.time()))
+        threadexec(self.cursor.execute, UPSERT, ("creation_time", old_value[0][0] if old_value else time.time()))
 
         threadexec(self.cursor.execute, DROP_OLD_TEMP)
         threadexec(self.cursor.execute, DROP_OLD_PERMA)

--- a/martools/marttools.py
+++ b/martools/marttools.py
@@ -95,8 +95,16 @@ class MartTools(Listeners, commands.Cog):
             old_value = result[0][0]
             threadexec(self.cursor.execute, UPSERT, (event_name, old_value))
 
-        old_value = list(threadexec(self.cursor.execute, SELECT_OLD, {"event": "creation_time"}))
-        threadexec(self.cursor.execute, UPSERT, ("creation_time", old_value[0][0] if old_value else time.time()))
+        old_value = list(
+            threadexec(
+                self.cursor.execute, SELECT_OLD, {"guild_id": -1000, "event": "creation_time"}
+            )
+        )
+        threadexec(
+            self.cursor.execute,
+            UPSERT,
+            ("creation_time", old_value[0][0] if old_value else time.time()),
+        )
 
         threadexec(self.cursor.execute, DROP_OLD_TEMP)
         threadexec(self.cursor.execute, DROP_OLD_PERMA)

--- a/martools/marttools.py
+++ b/martools/marttools.py
@@ -424,27 +424,23 @@ class MartTools(Listeners, commands.Cog):
                     _(
                         "Streams             : {streams_played}\n"
                         "YouTube Streams     : {yt_streams_played}\n"
-                        "Mixer Streams       : {mixer_streams_played}\n"
                         "Twitch Streams      : {ttv_streams_played}\n"
                         "Other Streams       : {streams_played}\n"
                         "YouTube Tracks      : {youtube_tracks}\n"
                         "Soundcloud Tracks   : {soundcloud_tracks}\n"
                         "Bandcamp Tracks     : {bandcamp_tracks}\n"
                         "Vimeo Tracks        : {vimeo_tracks}\n"
-                        "Mixer Tracks        : {mixer_tracks}\n"
                         "Twitch Tracks       : {twitch_tracks}\n"
                         "Other Tracks        : {other_tracks}\n"
                     ).format(
                         streams_played=self.get_value("streams_played", perma=True),
                         yt_streams_played=self.get_value("yt_streams_played", perma=True),
-                        mixer_streams_played=self.get_value("mixer_streams_played", perma=True),
                         ttv_streams_played=self.get_value("ttv_streams_played", perma=True),
                         other_streams_played=self.get_value("other_streams_played", perma=True),
                         youtube_tracks=self.get_value("youtube_tracks", perma=True),
                         soundcloud_tracks=self.get_value("soundcloud_tracks", perma=True),
                         bandcamp_tracks=self.get_value("bandcamp_tracks", perma=True),
                         vimeo_tracks=self.get_value("vimeo_tracks", perma=True),
-                        mixer_tracks=self.get_value("mixer_tracks", perma=True),
                         twitch_tracks=self.get_value("twitch_tracks", perma=True),
                         other_tracks=self.get_value("other_tracks", perma=True),
                     ),

--- a/martools/marttools.py
+++ b/martools/marttools.py
@@ -52,10 +52,13 @@ class MartTools(Listeners, commands.Cog):
         self.cache = {"perma": Counter(), "session": Counter()}
         self.uptime = datetime.utcnow()
 
+        self.init_task = self.bot.loop.create_task(self.initialize())
         self.dump_cache_task = self.bot.loop.create_task(self.__dump_cache_to_db())
 
     def cog_unload(self):
         self.dump_cache_task.cancel()
+        if self.init_task:
+            self.init_task.cancel()
 
         for event_name, value in self.cache["perma"].items():
             threadexec(self.cursor.execute, UPSERT, (event_name, value))

--- a/martools/marttools.py
+++ b/martools/marttools.py
@@ -114,12 +114,7 @@ class MartTools(Listeners, commands.Cog):
         threadexec(self.cursor.execute, DROP_OLD_PERMA)
         threadexec(
             self.cursor.execute,
-            (
-                "INSERT INTO version (version_num) "
-                "VALUES (2) "
-                "ON CONFLICT (version_num) "
-                "DO NOTHING"
-            ),
+            ("INSERT or IGNORE INTO version (version_num) VALUES (2)"),
         )
 
     async def __populate_cache(self):
@@ -299,7 +294,7 @@ class MartTools(Listeners, commands.Cog):
                 ).format_map(
                     {
                         "messages_read": self.get_value("messages_read", perma=True),
-                        "msg_sent": self.get_value("msg_sent"),
+                        "msg_sent": self.get_value("msg_sent", perma=True),
                         "messages_deleted": self.get_value("messages_deleted", perma=True),
                         "messages_edited": self.get_value("messages_edited", perma=True),
                         "dms_received": self.get_value("dms_received", perma=True),

--- a/martools/marttools.py
+++ b/martools/marttools.py
@@ -73,7 +73,6 @@ class MartTools(Listeners, commands.Cog):
         threadexec(self.cursor.execute, PRAGMA_wal_autocheckpoint)
         threadexec(self.cursor.execute, CREATE_TABLE)
         threadexec(self.cursor.execute, CREATE_VERSION_TABLE)
-        threadexec(self.cursor.execute, INSERT_DO_NOTHING, ("creation_time", time.time()))
 
         try:
             check_result = list(threadexec(self.cursor.execute, "SELECT * FROM bot_stats_perma"))
@@ -83,6 +82,8 @@ class MartTools(Listeners, commands.Cog):
         else:
             if check_result:
                 await self.__migrate_data()
+
+        threadexec(self.cursor.execute, INSERT_DO_NOTHING, ("creation_time", time.time()))
 
         await self.__populate_cache()
 
@@ -97,7 +98,7 @@ class MartTools(Listeners, commands.Cog):
 
         old_value = list(
             threadexec(
-                self.cursor.execute, SELECT_OLD, {"guild_id": -1000, "event": "creation_time"}
+                self.cursor.execute, SELECT_OLD, {"event": "creation_time", "guild_id": -1000}
             )
         )
         threadexec(

--- a/martools/marttools.py
+++ b/martools/marttools.py
@@ -39,7 +39,7 @@ class MartTools(Listeners, commands.Cog):
     """Multiple tools that are originally used on Martine."""
 
     __author__ = ["Predä", "Draper"]
-    __version__ = "2.0.0a"
+    __version__ = "2.0.0"
 
     async def red_delete_data_for_user(self, **kwargs):
         """Nothing to delete."""

--- a/martools/statements.py
+++ b/martools/statements.py
@@ -27,25 +27,18 @@ SELECT version_num
 FROM version
 """
 
-UPSERT = """INSERT INTO 
+UPSERT = """INSERT or REPLACE INTO 
 bot_stats 
   (event, quantity) 
 VALUES 
   (?, ?)
-ON CONFLICT
-  (event) 
-DO UPDATE 
-  SET quantity = quantity;
 """
 
-INSERT_DO_NOTHING = """INSERT INTO 
+INSERT_DO_NOTHING = """INSERT or IGNORE INTO 
 bot_stats 
   (event, quantity) 
 VALUES 
   (?, ?)
-ON CONFLICT
-  (event) 
-DO NOTHING;
 """
 
 GET_EVENT_VALUE = """
@@ -55,6 +48,7 @@ WHERE event
 LIKE :event;
 """
 
+# Only used for old data migrate.
 SELECT_OLD = """
 SELECT sum(quantity) 
 FROM bot_stats_perma 

--- a/martools/statements.py
+++ b/martools/statements.py
@@ -7,136 +7,63 @@ PRAGMA wal_autocheckpoint;
 PRAGMA_read_uncommitted = """
 PRAGMA read_uncommitted = 1;
 """
-CREATE_TABLE_PERMA = """CREATE TABLE IF NOT EXISTS
-   bot_stats_perma 
-        (
-        guild_id INTEGER NOT NULL,
-        event TEXT NOT NULL,
-        quantity INTEGER DEFAULT 1,
-        PRIMARY KEY 
-          (
-            guild_id, 
-            event
-          )
-        );
-"""
-CREATE_TABLE_TEMP = """CREATE TABLE IF NOT EXISTS
-   bot_stats_temp 
-        (
-        guild_id INTEGER NOT NULL,
-        event TEXT NOT NULL,
-        quantity INTEGER DEFAULT 1,
-        PRIMARY KEY 
-          (
-            guild_id, 
-            event
-          )
-        );
-"""
-
-
-UPSERT_PERMA = """INSERT INTO 
-bot_stats_perma 
+CREATE_TABLE = """CREATE TABLE IF NOT EXISTS
+  bot_stats 
   (
-    guild_id, 
-    event
-  ) 
+    event TEXT NOT NULL,
+    quantity INTEGER DEFAULT 1,
+    PRIMARY KEY (event)
+  );
+"""
+CREATE_VERSION_TABLE = """CREATE TABLE IF NOT EXISTS
+  version 
+  (
+    version_num INTEGER DEFAULT 1,
+    PRIMARY KEY (version_num)
+  );
+"""
+GET_VERSION = """
+SELECT version_num
+FROM version
+"""
+
+UPSERT = """INSERT INTO 
+bot_stats 
+  (event, quantity) 
 VALUES 
-  (
-    ?, 
-    ?
-  )
+  (?, ?)
 ON CONFLICT
-  (
-    guild_id, 
-    event
-  ) 
+  (event) 
 DO UPDATE 
-  SET quantity = quantity + 1;
+  SET quantity = quantity;
 """
 
-INSERT_PERMA_DO_NOTHING = """INSERT INTO 
-bot_stats_perma 
-  (
-    guild_id, 
-    event,
-    quantity
-  ) 
+INSERT_DO_NOTHING = """INSERT INTO 
+bot_stats 
+  (event, quantity) 
 VALUES 
-  (
-    ?,
-    ?,
-    ?
-  )
+  (?, ?)
 ON CONFLICT
-  (
-    guild_id, 
-    event
-  ) 
+  (event) 
 DO NOTHING;
 """
 
-UPSERT_TEMP = """INSERT INTO 
-bot_stats_temp 
-  (
-    guild_id, 
-    event
-  ) 
-VALUES 
-  (
-    ?, 
-    ?
-  )
-ON CONFLICT
-  (
-    guild_id, 
-    event
-  ) 
-DO UPDATE 
-  SET quantity = quantity + 1;
-"""
-DROP_TEMP = """
-DROP TABLE IF EXISTS bot_stats_temp;
-"""
-
-SELECT_TEMP = """
-SELECT * 
-FROM bot_stats_temp
+GET_EVENT_VALUE = """
+SELECT quantity
+FROM bot_stats
 WHERE event 
 LIKE :event;
 """
 
-SELECT_PERMA = """
-SELECT * 
-FROM bot_stats_perma
-WHERE event 
-LIKE :event;
-"""
-
-SELECT_PERMA_GLOBAL = """
+SELECT_OLD = """
 SELECT sum(quantity) 
 FROM bot_stats_perma 
 WHERE event = :event
 GROUP BY event;
 """
-
-SELECT_TEMP_GLOBAL = """
-SELECT sum(quantity) 
-FROM bot_stats_temp 
-WHERE event = :event
-GROUP BY event;
+DROP_OLD_TEMP = """
+DROP TABLE IF EXISTS bot_stats_temp
 """
-
-SELECT_PERMA_SINGLE = """
-SELECT sum(quantity) 
-FROM bot_stats_perma 
-WHERE event = :event AND guild_id = :guild_id
-GROUP BY event;
-"""
-
-SELECT_TEMP_SINGLE = """
-SELECT sum(quantity) 
-FROM bot_stats_temp 
-WHERE event = :event AND guild_id = :guild_id
-GROUP BY event;
+DROP_OLD_PERMA = """
+DROP TABLE IF EXISTS bot_stats_perma
 """

--- a/martools/utils.py
+++ b/martools/utils.py
@@ -1,21 +1,50 @@
-import functools
 from concurrent.futures._base import as_completed
 from concurrent.futures.thread import ThreadPoolExecutor
 from typing import List
 
-
-def rgetattr(obj, attr, *args):
-    def _getattr(obj2, attr2):
-        return getattr(obj2, attr2, *args)
-
-    return functools.reduce(_getattr, [obj] + attr.split("."))
+events_names = (
+    "on_error",
+    "msg_sent",
+    "dms_received",
+    "messages_read",
+    "guild_join",
+    "guild_remove",
+    "sessions_resumed",
+    "processed_commands",
+    "new_members",
+    "members_left",
+    "messages_deleted",
+    "messages_edited",
+    "reactions_added",
+    "reactions_removed",
+    "roles_added",
+    "roles_removed",
+    "roles_updated",
+    "members_banned",
+    "members_unbanned",
+    "emojis_removed",
+    "emojis_added",
+    "emojis_updated",
+    "users_joined_bot_music_room",
+    "tracks_played",
+    "streams_played",
+    "yt_streams_played",
+    "mixer_streams_played",
+    "ttv_streams_played",
+    "other_streams_played",
+    "youtube_tracks",
+    "soundcloud_tracks",
+    "bandcamp_tracks",
+    "vimeo_tracks",
+    "mixer_tracks",
+    "twitch_tracks",
+    "other_tracks",
+)
 
 
 def threadexec(func, *args) -> List:
     result = []
-    with ThreadPoolExecutor(max_workers=1) as executor:
-        for future in as_completed(
-                [executor.submit(func, *args)]
-        ):
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        for future in as_completed([executor.submit(func, *args)]):
             result = future.result()
     return result


### PR DESCRIPTION
- Add an internal cache.
- Use of that cache on listeners and commands.
- That cache is dumped with new values to the DB every 5 minutes, and at unloads.
- No longer storing guild IDs. It includes a migration tool launched automatically on load if it's an old DB.

All this will help bots that were having a very hard time with this cog, because of writes on all events to the DB.

Closes #50.