### PR TITLE
[RandImages] fix birb and coffee commands

### DIFF
--- a/randimages/randimages.py
+++ b/randimages/randimages.py
@@ -33,7 +33,7 @@ class RandImages(Core):
             name=_("birb"),
             emoji="\N{BIRD}",
             source="alexflipnote API",
-            img_url="https://api.alexflipnote.xyz/birb",
+            img_url="https://api.alexflipnote.dev/birb",
             img_arg="file",
             facts=False,
         )
@@ -83,7 +83,7 @@ class RandImages(Core):
             name=_("your coffee"),
             emoji="\N{HOT BEVERAGE}",
             source="alexflipnote API",
-            img_url="https://coffee.alexflipnote.xyz/random.json",
+            img_url="https://coffee.alexflipnote.dev/random.json",
             img_arg="file",
             facts=False,
         )


### PR DESCRIPTION
Hi,

AlexFlipnote has moved to `.dev` domain from his old `.xyz` domain now since a while, and he recently made announcement where he said birb endpoint no longer require API key now, and coffee endpoint is always openly accessible for public. 😛 I can confirm my changes works after testing on my bot.

![2021-05-04_09-39](https://user-images.githubusercontent.com/24418520/116959920-a19a3880-acbc-11eb-8fd9-a7a9ef782fde.png)

and thanks for making this cog.