### PR TITLE
[RandImages] remove `text` variable from `_get_reddit_imgs_details` method

### DIFF
--- a/randimages/core.py
+++ b/randimages/core.py
@@ -110,9 +110,8 @@ class Core(commands.Cog):
                     url = url[:-3] + "gif"
                 elif url.endswith(".gifv"):
                     url = url[:-1]
-                elif (
-                    not url.endswith(GOOD_EXTENSIONS)
-                    and not url.startswith("https://gfycat.com")
+                elif not url.endswith(GOOD_EXTENSIONS) and not url.startswith(
+                    "https://gfycat.com"
                 ):
                     url, subr, author, title, post = await self._get_reddit_imgs_details(
                         ctx, sub=sub


### PR DESCRIPTION
Current implementation throws `UnboundLocalError` exception in rare cases: https://sentry.io/share/issue/398d5ad4db064f8499417d9524f182a5/